### PR TITLE
Fix: 동일 페이지 id에서 여러번 신고시 응답 변경

### DIFF
--- a/src/components/common/modal/ReportModal.tsx
+++ b/src/components/common/modal/ReportModal.tsx
@@ -51,12 +51,21 @@ export default function ReportModal({
     }
 
     try {
-      await axiosInstance.post(url, body);
-      toast.success('신고가 접수되었습니다.');
+      const res = await axiosInstance.post(url, body);
+      const code = res.data?.code;
+
+      if (code === '4099') {
+        toast.info('이미 신고한 콘텐츠입니다.');
+      } else if (code === '2000') {
+        toast.success('신고가 접수되었습니다.');
+      } else {
+        toast.error('알 수 없는 응답입니다.');
+      }
+
       onClose();
     } catch (err) {
-      console.error(err);
       toast.error('신고 처리 중 오류가 발생했습니다.');
+      console.error('❌ 신고 실패:', err);
     }
   };
 

--- a/src/components/sharemap/ShareClickDetail.tsx
+++ b/src/components/sharemap/ShareClickDetail.tsx
@@ -194,11 +194,8 @@ export default function ShareClickDetail() {
               <button>
                 <Siren
                   size={18}
-                  className="cursor-pointer"
-                  onClick={() => {
-                    console.log('신고 대상 ID:', id);
-                    setIsReportOpen(true);
-                  }}
+                  className="cursor-pointer text-red-500"
+                  onClick={() => setIsReportOpen(true)}
                 />
               </button>
             </div>

--- a/src/components/sharemap/ShareMapJoin.tsx
+++ b/src/components/sharemap/ShareMapJoin.tsx
@@ -193,7 +193,11 @@ export default function ShareMapJoin() {
                 <span>{roadmap?.viewCount}</span>
               </div>
               <button onClick={() => setIsReportOpen(true)}>
-                <Siren className="cursor-pointer" size={18} />
+                <Siren
+                  size={18}
+                  className="cursor-pointer text-red-500"
+                  onClick={() => setIsReportOpen(true)}
+                />
               </button>
             </div>
           </div>


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

동일 페이지 id에서 여러번 신고시 응답 변경

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)


## 💬 공유사항 to 리뷰어

이미 신고한 페이지나 마커, 퀘스트에서 또 신고를 하면 "이미 신고한 콘텐츠입니다"가 나오게 바꿨습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
